### PR TITLE
Fix specs against rspec3

### DIFF
--- a/orel.gemspec
+++ b/orel.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
   s.add_development_dependency 'database_cleaner'

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -31,8 +31,8 @@ describe Orel::Attributes do
       subject.should_not be_empty
     end
     it "can tell you if it has an attribute or not" do
-      subject.att?(:name).should be_true
-      subject.att?(:foo).should be_false
+      subject.att?(:name).should be_truthy
+      subject.att?(:foo).should be_falsey
     end
     it "can get and set the value of an attribute" do
       subject[:name].should be_nil
@@ -78,7 +78,7 @@ describe Orel::Attributes do
   describe "conformance to ActiveModel::Dirty" do
     describe "at first, without default values" do
       subject { Orel::Attributes.new(thing_heading) }
-      its(:changed?) { should be_false }
+      its(:changed?) { should be_falsey }
       its(:changed) { should be_empty }
       its(:changes) { should be_empty }
       its(:previous_changes) { should be_empty }
@@ -86,7 +86,7 @@ describe Orel::Attributes do
     end
     describe "at first, with default values" do
       subject { Orel::Attributes.new(thing_heading, :name => "John") }
-      its(:changed?) { should be_false }
+      its(:changed?) { should be_falsey }
       its(:changed) { should be_empty }
       its(:changes) { should be_empty }
       its(:previous_changes) { should be_empty }
@@ -97,7 +97,7 @@ describe Orel::Attributes do
       before do
         subject[:name] = "Bob"
       end
-      its(:changed?) { should be_true }
+      its(:changed?) { should be_truthy }
       its(:changed) { should == [:name] }
       its(:changes) { should == { :name => [nil, 'Bob'] } }
       its(:previous_changes) { should be_empty }
@@ -108,7 +108,7 @@ describe Orel::Attributes do
       before do
         subject[:name] = "Bob"
       end
-      its(:changed?) { should be_true }
+      its(:changed?) { should be_truthy }
       its(:changed) { should == [:name] }
       its(:changes) { should == { :name => ['John', 'Bob'] } }
       its(:previous_changes) { should be_empty }

--- a/spec/class_associations_spec.rb
+++ b/spec/class_associations_spec.rb
@@ -43,7 +43,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::Thing] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::Thing] }.not_to raise_error
       end
     end
     context "when records have been stored" do
@@ -56,7 +56,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::Thing] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::Thing] }.not_to raise_error
       end
     end
   end
@@ -93,7 +93,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::User] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::User] }.not_to raise_error
       end
     end
     context "when records have been stored" do
@@ -105,7 +105,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::User] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::User] }.not_to raise_error
       end
     end
   end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -3,8 +3,8 @@ require 'helper'
 describe Orel::Connection do
 
   let(:active_record_connection) { stub("ar connection") }
-  let(:active_record) { stub("AR", :connection => active_record_connection) }
-  subject { described_class.new(active_record) }
+  let(:active_record) { double("AR", :connection => active_record_connection) }
+  subject { Orel::Connection.new(active_record) }
 
   describe ".arel_table" do
     it "always returns the same instance for a heading" do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -27,7 +27,15 @@ RSpec.configure do |config|
   end
   config.before(:suite) do
     Orel.finalize!
-    Orel.recreate_database!
+    begin
+      # This used to work, but now mysql2 throws an error during connect if the
+      # database does not exist. That means there's no way to create the db via
+      # the AR connection.
+      Orel.recreate_database!
+    rescue => e
+      STDERR.puts "Creating DB via CLI. If this fails, you may need to manually create orel_test. (#{e})"
+      `echo 'create database orel_test' | mysql -uroot`
+    end
     Orel.create_tables!
     DatabaseCleaner.strategy = :transaction
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,8 @@
 require 'orel'
 require 'rspec'
+require 'rspec/its'
 require 'database_cleaner'
+require 'fileutils'
 
 OREL_LOG_FILE = File.dirname(__FILE__) + "/../log/test.log"
 
@@ -17,6 +19,12 @@ ActiveRecord::Base.establish_connection(
 require 'fixtures/users_and_things'
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :should
+  end
   config.before(:suite) do
     Orel.finalize!
     Orel.recreate_database!

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -113,7 +113,7 @@ describe Orel::Object do
   describe "saving records" do
     shared_examples "an invalid record being saved" do
       specify "#save returns false and does not persist the record" do
-        subject.save.should be_false
+        subject.save.should be_falsey
         klass.table.row_count.should == 0
       end
       specify "#save! raises an error and does not persist the record" do
@@ -124,7 +124,7 @@ describe Orel::Object do
 
     shared_examples "a valid record being saved" do
       specify "#save returns true and persists the record" do
-        subject.save.should be_true
+        subject.save.should be_truthy
         klass.table.row_count.should == 1
       end
       specify "#save! returns true and persists the record" do
@@ -165,7 +165,7 @@ describe Orel::Object do
         subject.first_name = nil
       end
       specify "#save returns false and does not update the record" do
-        subject.save.should be_false
+        subject.save.should be_falsey
         UsersAndThings::User.table.row_count.should == 1
         UsersAndThings::User.table.row_list.first[:first_name].should == "John"
       end
@@ -177,7 +177,7 @@ describe Orel::Object do
         subject.first_name = "Dave"
       end
       specify "#save returns true and persists the record" do
-        subject.save.should be_true
+        subject.save.should be_truthy
         UsersAndThings::User.table.row_count.should == 1
         UsersAndThings::User.table.row_list.first[:first_name].should == "Dave"
       end

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -128,7 +128,7 @@ describe Orel::Object do
         klass.table.row_count.should == 1
       end
       specify "#save! returns true and persists the record" do
-        expect { subject.save! }.not_to raise_error(Orel::Object::InvalidRecord)
+        expect { subject.save! }.not_to raise_error
         klass.table.row_count.should == 1
       end
     end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -19,7 +19,7 @@ describe Orel::Options do
       subject { described_class.new(Object) }
       its(:prefix) { should be_nil }
       its(:suffix) { should be_nil }
-      its(:pluralize) { should be_true }
+      its(:pluralize) { should be_truthy }
       its(:active_record) { should == Orel::AR }
     end
 
@@ -27,7 +27,7 @@ describe Orel::Options do
       subject { described_class.new(Group) }
       its(:prefix) { should == "rel_prefix" }
       its(:suffix) { should == "rel_suffix" }
-      its(:pluralize) { should be_false }
+      its(:pluralize) { should be_falsey }
       its(:active_record) { should == :active_record }
     end
   end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -9,9 +9,11 @@ describe Orel::Relation do
     end
     it "uses the base active record connection by default" do
       pending
+      fail
     end
     it "uses a configured active record connection" do
       pending
+      fail
     end
   end
 
@@ -21,6 +23,7 @@ describe Orel::Relation do
     end
     it "returns a child heading" do
       pending
+      fail
     end
     it "raises an error if asking for a non-existent child" do
       expect {
@@ -35,6 +38,7 @@ describe Orel::Relation do
     end
     it "returns a table for a child heading" do
       pending
+      fail
     end
     it "raises an error if asking for a non-existent child" do
       expect {


### PR DESCRIPTION
With a fresh `bundle install` I get rspec 3.1.0. This updates some deprecation issues so that the test suite passes. It does not make any unnecessary syntax changes to modernize the test suite. That should be done in an ongoing basis and/or as a separate change.
