### PR TITLE
Query and return the result in batches

### DIFF
--- a/lib/orel/query.rb
+++ b/lib/orel/query.rb
@@ -181,6 +181,11 @@ module Orel
         count = options[:batch_size]
         group = options[:group] || false
         # Always order by the key.
+        # NOTE: it may be desirable to not set this, or optionally set it in
+        # order to do Consistent Nonlocking Reads. I can't think of a way to
+        # start/end the transaction within the Enumerator though, so the caller
+        # would need to do it.
+        # http://dev.mysql.com/doc/refman/5.0/en/innodb-consistent-read.html
         @heading.attributes.each { |a|
           manager.order table[a.name]
         }

--- a/lib/orel/query.rb
+++ b/lib/orel/query.rb
@@ -141,7 +141,8 @@ module Orel
     #
     # description - String description of the query for logging (default: none).
     # options     - Specify batching options:
-    #               :batch_size - Number.
+    #               :batch_size - Number max records per batch.
+    #               :group      - Boolean whether yield batches or objects.
     #
     # Yields Orel::Query::Select, Orel::Query::Relation
     #
@@ -200,6 +201,9 @@ module Orel
           end
         end
       else
+        if options.any?
+          raise ArgumentError, "Options were set, but not :batch_size"
+        end
         batch.read_all
       end
     end

--- a/lib/orel/query.rb
+++ b/lib/orel/query.rb
@@ -158,6 +158,7 @@ module Orel
         # and end position.
         start = 0
         count = options[:batch_size]
+        group = options[:group] || false
         # Always order by the key.
         @heading.attributes.each { |a|
           manager.order table[a.name]
@@ -166,7 +167,13 @@ module Orel
           loop do
             objects = batch.read_batch(start, count)
             start += count
-            e.yield objects
+            if group
+              e.yield objects
+            else
+              objects.each do |obj|
+                e.yield obj
+              end
+            end
             if objects.size < count
               break
             end

--- a/lib/orel/query.rb
+++ b/lib/orel/query.rb
@@ -18,6 +18,26 @@ module Orel
   # Following is a description of how to use the select and relation objects
   # to construct a query.
   #
+  # Queries can be returned in one or many result sets. By specifying "batch"
+  # options, the number of results is limited. This is useful for iterating
+  # over very large sets of data. The  result of a batch query is an Enumerator
+  # object.
+  #
+  # Specify `batch_size` to the max number of records to return.
+  #
+  #     users = User.query(:batch_size => 1000)
+  #     users.each do |user|
+  #     end
+  #
+  # Specify `group` to give each batch as an Array, rather than each object one
+  # at a time.
+  #
+  #     users = User.query(:batch_size => 1000, :group => true)
+  #     users.each do |batch|
+  #       batch.size # => 1000
+  #       batch.each do |user|
+  #       end
+  #     end
   #
   # Relation
   #

--- a/orel.gemspec
+++ b/orel.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
   s.add_development_dependency 'database_cleaner'

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -31,8 +31,8 @@ describe Orel::Attributes do
       subject.should_not be_empty
     end
     it "can tell you if it has an attribute or not" do
-      subject.att?(:name).should be_true
-      subject.att?(:foo).should be_false
+      subject.att?(:name).should be_truthy
+      subject.att?(:foo).should be_falsey
     end
     it "can get and set the value of an attribute" do
       subject[:name].should be_nil
@@ -78,7 +78,7 @@ describe Orel::Attributes do
   describe "conformance to ActiveModel::Dirty" do
     describe "at first, without default values" do
       subject { Orel::Attributes.new(thing_heading) }
-      its(:changed?) { should be_false }
+      its(:changed?) { should be_falsey }
       its(:changed) { should be_empty }
       its(:changes) { should be_empty }
       its(:previous_changes) { should be_empty }
@@ -86,7 +86,7 @@ describe Orel::Attributes do
     end
     describe "at first, with default values" do
       subject { Orel::Attributes.new(thing_heading, :name => "John") }
-      its(:changed?) { should be_false }
+      its(:changed?) { should be_falsey }
       its(:changed) { should be_empty }
       its(:changes) { should be_empty }
       its(:previous_changes) { should be_empty }
@@ -97,7 +97,7 @@ describe Orel::Attributes do
       before do
         subject[:name] = "Bob"
       end
-      its(:changed?) { should be_true }
+      its(:changed?) { should be_truthy }
       its(:changed) { should == [:name] }
       its(:changes) { should == { :name => [nil, 'Bob'] } }
       its(:previous_changes) { should be_empty }
@@ -108,7 +108,7 @@ describe Orel::Attributes do
       before do
         subject[:name] = "Bob"
       end
-      its(:changed?) { should be_true }
+      its(:changed?) { should be_truthy }
       its(:changed) { should == [:name] }
       its(:changes) { should == { :name => ['John', 'Bob'] } }
       its(:previous_changes) { should be_empty }

--- a/spec/class_associations_spec.rb
+++ b/spec/class_associations_spec.rb
@@ -43,7 +43,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::Thing] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::Thing] }.not_to raise_error
       end
     end
     context "when records have been stored" do
@@ -56,7 +56,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::Thing] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::Thing] }.not_to raise_error
       end
     end
   end
@@ -93,7 +93,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::User] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::User] }.not_to raise_error
       end
     end
     context "when records have been stored" do
@@ -105,7 +105,7 @@ describe Orel::ClassAssociations do
       end
       it "does not throw locked for query errors" do
         subject.locked_for_query = true
-        expect { subject[UsersAndThings::User] }.not_to raise_error(Orel::LockedForQueryError)
+        expect { subject[UsersAndThings::User] }.not_to raise_error
       end
     end
   end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -3,8 +3,8 @@ require 'helper'
 describe Orel::Connection do
 
   let(:active_record_connection) { stub("ar connection") }
-  let(:active_record) { stub("AR", :connection => active_record_connection) }
-  subject { described_class.new(active_record) }
+  let(:active_record) { double("AR", :connection => active_record_connection) }
+  subject { Orel::Connection.new(active_record) }
 
   describe ".arel_table" do
     it "always returns the same instance for a heading" do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -27,7 +27,15 @@ RSpec.configure do |config|
   end
   config.before(:suite) do
     Orel.finalize!
-    Orel.recreate_database!
+    begin
+      # This used to work, but now mysql2 throws an error during connect if the
+      # database does not exist. That means there's no way to create the db via
+      # the AR connection.
+      Orel.recreate_database!
+    rescue => e
+      STDERR.puts "Creating DB via CLI. If this fails, you may need to manually create orel_test. (#{e})"
+      `echo 'create database orel_test' | mysql -uroot`
+    end
     Orel.create_tables!
     DatabaseCleaner.strategy = :transaction
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,8 @@
 require 'orel'
 require 'rspec'
+require 'rspec/its'
 require 'database_cleaner'
+require 'fileutils'
 
 OREL_LOG_FILE = File.dirname(__FILE__) + "/../log/test.log"
 
@@ -17,6 +19,12 @@ ActiveRecord::Base.establish_connection(
 require 'fixtures/users_and_things'
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :should
+  end
   config.before(:suite) do
     Orel.finalize!
     Orel.recreate_database!

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -113,7 +113,7 @@ describe Orel::Object do
   describe "saving records" do
     shared_examples "an invalid record being saved" do
       specify "#save returns false and does not persist the record" do
-        subject.save.should be_false
+        subject.save.should be_falsey
         klass.table.row_count.should == 0
       end
       specify "#save! raises an error and does not persist the record" do
@@ -124,7 +124,7 @@ describe Orel::Object do
 
     shared_examples "a valid record being saved" do
       specify "#save returns true and persists the record" do
-        subject.save.should be_true
+        subject.save.should be_truthy
         klass.table.row_count.should == 1
       end
       specify "#save! returns true and persists the record" do
@@ -165,7 +165,7 @@ describe Orel::Object do
         subject.first_name = nil
       end
       specify "#save returns false and does not update the record" do
-        subject.save.should be_false
+        subject.save.should be_falsey
         UsersAndThings::User.table.row_count.should == 1
         UsersAndThings::User.table.row_list.first[:first_name].should == "John"
       end
@@ -177,7 +177,7 @@ describe Orel::Object do
         subject.first_name = "Dave"
       end
       specify "#save returns true and persists the record" do
-        subject.save.should be_true
+        subject.save.should be_truthy
         UsersAndThings::User.table.row_count.should == 1
         UsersAndThings::User.table.row_list.first[:first_name].should == "Dave"
       end

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -128,7 +128,7 @@ describe Orel::Object do
         klass.table.row_count.should == 1
       end
       specify "#save! returns true and persists the record" do
-        expect { subject.save! }.not_to raise_error(Orel::Object::InvalidRecord)
+        expect { subject.save! }.not_to raise_error
         klass.table.row_count.should == 1
       end
     end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -19,7 +19,7 @@ describe Orel::Options do
       subject { described_class.new(Object) }
       its(:prefix) { should be_nil }
       its(:suffix) { should be_nil }
-      its(:pluralize) { should be_true }
+      its(:pluralize) { should be_truthy }
       its(:active_record) { should == Orel::AR }
     end
 
@@ -27,7 +27,7 @@ describe Orel::Options do
       subject { described_class.new(Group) }
       its(:prefix) { should == "rel_prefix" }
       its(:suffix) { should == "rel_suffix" }
-      its(:pluralize) { should be_false }
+      its(:pluralize) { should be_falsey }
       its(:active_record) { should == :active_record }
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -138,7 +138,29 @@ describe Orel::Query, "#query with batch enumeration" do
 
   let(:user_query)  { Orel::Query.new(UsersAndThings::User) }
 
-  it "queries batches, yielding batches" do
+  it "queries batches, yielding each object" do
+    results = user_query.query(:batch_size => 2) { |q, user|
+      # nothing
+    }
+    expect(results).to be_instance_of(Enumerator)
+    expect_users = [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g"
+    ]
+    actual_users = 0
+    results.each.with_index do |u, i|
+      actual_users += 1
+      expect(u.first_name).to eql(expect_users[i])
+    end
+    expect(actual_users).to eq(expect_users.size)
+  end
+
+  it "queries batches, yielding groups" do
     results = user_query.query(:batch_size => 2, :group => true) { |q, user|
       # nothing
     }
@@ -160,26 +182,10 @@ describe Orel::Query, "#query with batch enumeration" do
     expect(actual_batches).to eq(expect_batches.size)
   end
 
-  it "queries batches, yielding each object" do
-    results = user_query.query(:batch_size => 2) { |q, user|
-      # nothing
-    }
-    expect(results).to be_instance_of(Enumerator)
-    expect_users = [
-      "a",
-      "b",
-      "c",
-      "d",
-      "e",
-      "f",
-      "g"
-    ]
-    actual_users = 0
-    results.each.with_index do |u, i|
-      actual_users += 1
-      expect(u.first_name).to eql(expect_users[i])
-    end
-    expect(actual_users).to eq(expect_users.size)
+  it "is an error to specify :group without :batch_size" do
+    expect {
+      user_query.query(:group => true)
+    }.to raise_error(ArgumentError)
   end
 
   it "queries batches with conditions" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -138,8 +138,8 @@ describe Orel::Query, "#query with batch enumeration" do
 
   let(:user_query)  { Orel::Query.new(UsersAndThings::User) }
 
-  it "enumerates in batches" do
-    results = user_query.query(:batch_size => 2) { |q, user|
+  it "queries batches, yielding batches" do
+    results = user_query.query(:batch_size => 2, :group => true) { |q, user|
       # nothing
     }
     expect(results).to be_instance_of(Enumerator)
@@ -160,8 +160,30 @@ describe Orel::Query, "#query with batch enumeration" do
     expect(actual_batches).to eq(expect_batches.size)
   end
 
-  it "enumerates in batches with conditions" do
+  it "queries batches, yielding each object" do
     results = user_query.query(:batch_size => 2) { |q, user|
+      # nothing
+    }
+    expect(results).to be_instance_of(Enumerator)
+    expect_users = [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g"
+    ]
+    actual_users = 0
+    results.each.with_index do |u, i|
+      actual_users += 1
+      expect(u.first_name).to eql(expect_users[i])
+    end
+    expect(actual_users).to eq(expect_users.size)
+  end
+
+  it "queries batches with conditions" do
+    results = user_query.query(:batch_size => 2, :group => true) { |q, user|
       q.where user[:first_name].lteq("d")
       q.where user[:first_name].gteq("b")
     }
@@ -185,6 +207,9 @@ describe Orel::Query, "#query with batch enumeration" do
     results = user_query.query("testing", :batch_size => 2) { |q, user|
       # nothing
     }
+    results.each do |u|
+      # nothing
+    end
     expect(results).to be_instance_of(Enumerator)
   end
 end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -9,9 +9,11 @@ describe Orel::Relation do
     end
     it "uses the base active record connection by default" do
       pending
+      fail
     end
     it "uses a configured active record connection" do
       pending
+      fail
     end
   end
 
@@ -21,6 +23,7 @@ describe Orel::Relation do
     end
     it "returns a child heading" do
       pending
+      fail
     end
     it "raises an error if asking for a non-existent child" do
       expect {
@@ -35,6 +38,7 @@ describe Orel::Relation do
     end
     it "returns a table for a child heading" do
       pending
+      fail
     end
     it "raises an error if asking for a non-existent child" do
       expect {


### PR DESCRIPTION
This implements the ability to chunk the results into batches.

View this diff while #2 is pending: https://github.com/rcarver/orel/compare/rc-rspec3...rc-batch-query?w=1

---

Call `query_batches` to enable batch results. The result is an `Enumerator` instead of an `Array`. 

```
users = User.query do |q, u|
  q.query_batches :size => 1000
  q.where u[:first_name].eq("Joe")
end
users.each do |user|
   # do stuff with user
end
```

Pass `:group => true` to yield each batch as an array, instead of enumerating each object.

```
# with grouping
users = User.query do |q, u|
  q.query_batches :size => 1000, :group => true
  q.where u[:first_name].eq("Joe")
end
users.each do |batch|
  batch.each do |user
    # do stuff with user
  end
end
```
